### PR TITLE
CLI-To-Whatsapp: Improve script portability

### DIFF
--- a/whatsapp_message.sh
+++ b/whatsapp_message.sh
@@ -1,8 +1,7 @@
-#!/bin/bash
-read -p "Enter the phone number of receiver in international format: " phoneNumber
-read -p "Enter the command you want to execute: " rhelCommand
-message="`$rhelCommand`"
-messages=`echo $message | sed 's/ /%20/g' | sed 's/+/%20/g'`
-#gio open https://wa.me/$phoneNumber?text=$message
+#!/usr/bin/env bash
+read -p "Enter the phone number of receiver in international format: " -r phoneNumber
+read -p "Enter the command you want to execute: " -r rhelCommand
+messages="$(sed 's/ /%20/g; s/+/%20/g' <<< "$($rhelCommand)")"
+#gio open https://wa.me/$phoneNumber?text=$messages
 link="https://web.whatsapp.com/send?phone=$phoneNumber&text=$messages"
-echo $link
+printf '\n\033[4;94m%s\033[0m\n' "$link"


### PR DESCRIPTION
- Backticks (`) deprecated; $() POSIX compatible too

- #!/bin/bash vs #!/usr/bin/env bash: `env` finds default bash for Users current environment

- Unnecessary to pipe `sed` into `sed`, invoking twice, or to `echo` to manipulate variable

Misc:
- Print link in blue colour to indicate URL